### PR TITLE
[NetHack | CDZ] Final pre-launch NetHack website updates

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -24,15 +24,12 @@ You can read more about NLE in the [NeurIPS 2020 paper](https://arxiv.org/abs/20
 
 ![Example of an agent running on NLE](https://github.com/facebookresearch/nle/raw/master/dat/nle/example_run.gif)
 
-### How to participate?
-
-The competition rules and submission instructions will be published soon. Stay tuned! In the meantime, you can follow us on [Twitter](https://twitter.com/NetHack_LE), join our [Discord server](https://discord.gg/zkFWQmSWBA) or get acquainted with the [NetHack Learning Environment](https://github.com/facebookresearch/nle).
 
 ### New Challenge Open for NetHack 2021
 
-We are excited to launch the [NetHack Challenge](https://nethackchallenge.com/) (@NetHack_LE) with a #NeurIPS2021 competition! We are eagerly looking forward to the wide variety of submissions from machine learning students, researchers, and NetHack-bot builders.
+We are excited to launch the NetHack Challenge (@NetHack_LE) with a #NeurIPS2021 competition! We are eagerly looking forward to the wide variety of submissions from machine learning students, researchers, and NetHack-bot builders.
 
-The [NetHack Challenge](https://nethackchallenge.com/) invites entrants, using any method they choose, to develop agents that can reliably either beat the full game of NetHack or achieve as high a score as possible. No restrictions are placed on how the agent is trained and contestants will use their own hardware. Evaluation will be performed in a controlled setting, thanks to our partner and co-organizer, [AIcrowd](https://www.aicrowd.com/challenges/neurips-2021-nethack-challenge).
+The NetHack Challenge invites entrants, using any method they choose, to develop agents that can reliably either beat the full game of NetHack or achieve as high a score as possible. No restrictions are placed on how the agent is trained and contestants will use their own hardware. Evaluation will be performed in a controlled setting, thanks to our partner and co-organizer, [AIcrowd](https://www.aicrowd.com/challenges/neurips-2021-nethack-challenge).
 
 #### Participation Information:
 There will be three competition tracks:
@@ -40,7 +37,7 @@ There will be three competition tracks:
 2. **Best agent not using a neural network** - awarded to the best-performing agent not using a neural network or significantly similar modeling technique.
 3. **Best agent from an academic/independent team** - awarded to the best-performing agent produced by a team predominantly led by non-industry-affiliated researchers.
 
-The competition runs from early June through October 15, and the winners will be announced at NeurIPS in December. <!-- For more information, read our blog [here](#). -->You can also follow us on [Twitter](https://twitter.com/NetHack_LE), join our [Discord server](https://discord.gg/zkFWQmSWBA), or get acquainted with the [NetHack Learning Environment](https://github.com/facebookresearch/nle).
+The competition runs from early June through October 15, and the winners will be announced at NeurIPS in December. For more information, read our blog [here](https://ai.facebook.com/blog/launching-the-nethack-challenge-at-neurips-2021). You can also follow us on [Twitter](https://twitter.com/NetHack_LE), join our [Discord server](https://discord.gg/zkFWQmSWBA), or get acquainted with the [NetHack Learning Environment](https://github.com/facebookresearch/nle).
 
 ### Key Dates
 


### PR DESCRIPTION
Final pre-launch NetHack website updates

1. Remove "How to participate" section since it's now written in the New Challenge Open section
2. Remove the hyperlinks to NetHack Challenge since it links to its own website
3. Hyperlink "here" to the NetHack blog post (client understands that this will be 404 until the post is published)

Before | After
------------ | -------------
<img width="1029" alt="Screen Shot 2021-06-08 at 3 54 09 PM" src="https://user-images.githubusercontent.com/21027134/121270769-2efe1900-c877-11eb-9432-6eb45eab2082.png"> | <img width="1198" alt="Screen Shot 2021-06-08 at 3 53 38 PM" src="https://user-images.githubusercontent.com/21027134/121270767-2c9bbf00-c877-11eb-9f0f-7fb958ea64db.png">


