### PR TITLE
Post Launch Updates – social outbound-link icons, address logo flicker, jQuery for Bootstrap

### DIFF
--- a/_includes/social-section.html
+++ b/_includes/social-section.html
@@ -2,31 +2,46 @@
     <div class="social-link-wrapper">
         <a class="social-link" href="{{site.AIcrowd_url | relative_url}}" target="_blank">
             <img class="social-icon" src="{{site.images_uri | relative_url}}AIcrowd_Samurai3.svg" alt="Challenge" />
-           Challenge
+            Challenge
+            <span class="social-outbound-icon">
+                <img class="social-icon" src="{{site.images_uri | relative_url}}Outbound_Link.svg" alt="Discord" />
+            </span>
         </a>
     </div>
     <div class="social-link-wrapper">
         <a class="social-link" href="{{site.discord_url}}" target="_blank">
             <img class="social-icon" src="{{site.images_uri | relative_url}}Discord_Icon.svg" alt="Discord" />
             Discord
+            <span class="social-outbound-icon">
+                <img class="social-icon" src="{{site.images_uri | relative_url}}Outbound_Link.svg" alt="Discord" />
+            </span>
         </a>
     </div>
     <div class="social-link-wrapper">
         <a class="social-link" href="{{site.twitter_url}}" target="_blank">
             <img class="social-icon" src="{{site.images_uri | relative_url}}Twitter_Icon.svg" alt="Twitter" />
             Twitter
+            <span class="social-outbound-icon">
+                <img class="social-icon" src="{{site.images_uri | relative_url}}Outbound_Link.svg" alt="Discord" />
+            </span>
         </a>
     </div>
     <div class="social-link-wrapper">
         <a class="social-link" href="{{site.github_url}}" target="_blank">
             <img class="social-icon" src="{{site.images_uri | relative_url}}GitHub_Icon.svg" alt="GitHub" />
             NLE GitHub
+            <span class="social-outbound-icon">
+                <img class="social-icon" src="{{site.images_uri | relative_url}}Outbound_Link.svg" alt="Discord" />
+            </span>
         </a>
     </div>
     <div class="social-link-wrapper">
         <a class="social-link" href="{{site.paper_url}}" target="_blank">
             <img class="social-icon paper" src="{{site.images_uri | relative_url}}Paper_Icon.svg" alt="Paper" />
             NLE Paper
+            <span class="social-outbound-icon">
+                <img class="social-icon" src="{{site.images_uri | relative_url}}Outbound_Link.svg" alt="Discord" />
+            </span>
         </a>
     </div>
 </div>

--- a/_layouts/2021.html
+++ b/_layouts/2021.html
@@ -15,6 +15,9 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
     integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
 
+  <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+
   <!-- Latest compiled and minified JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
     integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
@@ -67,7 +70,6 @@
     {% include resources-section.html %}
 
   </section>
-
   <section class="team-section">
 
     {% include team-section.html %}

--- a/images/Outbound_Link.svg
+++ b/images/Outbound_Link.svg
@@ -1,0 +1,14 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="16" height="16">
+<rect width="16" height="16" transform="matrix(-4.37114e-08 -1 -1 4.37114e-08 16 16)" fill="url(#pattern0)"/>
+</mask>
+<g mask="url(#mask0)">
+<rect width="16" height="16" transform="matrix(-4.37114e-08 -1 -1 4.37114e-08 16 16)" fill="white"/>
+</g>
+<defs>
+<pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0" transform="scale(0.025)"/>
+</pattern>
+<image id="image0" width="40" height="40" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAAXNSR0IArs4c6QAAAbBJREFUWAntmDtOxDAQhhc6bgLcgm05CBeAI1DQQwl7CE5BxzkQHaJASMD/gRyNPM5j/UiElJFm7Ywdz5d/djeWN5vV2iiw1bKP8hf5l/x7gn9ozrU8tgsF3uVT1mDOp/xGnrQjRe/kU6HipG+JVZ8Vi+eNXQOZNODGbu4br6VgWN8BUlar3E7Xp/JDN7Ne4EBL3csDlG1dFr5zYcKDG60fGIKDwxk/iACIci0tBRcr6fLb8s5dVuCADgIlFRwcdI+TF+hTjjg2yDA4+Hd/0ecY3KKAU+AWA5wKtwjgPnCzA+4LB2B4Z9M6q/kjyYEDiI0F725aZ7UAc+EcUByoAdgMDthSwKZwNQDPo4cMry/WrmKlClrAXDh25Gx6UzvzKiUGEqfcOcamF6Fof80uxEAwGw+xOVrH0HJbVeWBVsBSGVcFVwVLFSi9/199B+2f5BLgNmfHYoOvphzHpj9X98Qk6lgs4JOZcGX6c3UvTSLL0oW36tnThZ2uWx8eIRA5yEVZcRjO5Em7VTRMXKqFoddKDzBLHgrlOJ+EYdQo975HwDlwQHGqRq7esmpstWwFfgDewlpF6C4RFgAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/theme-css/style2021.css
+++ b/theme-css/style2021.css
@@ -51,6 +51,7 @@ header {
   display: block;
   margin: 24px 24px 24px 0;
   max-width: 333px;
+  -webkit-transform:translate3d(0,0,0);
 }
 
 .header-wrapper .header-description {
@@ -134,7 +135,7 @@ header {
   font-size: 14px;
   letter-spacing: 3px;
   margin-bottom: 36px;
-  max-width: 175px;
+  max-width: 212px;
 }
 
 .hp-body .social-link:hover {
@@ -147,6 +148,10 @@ header {
 
 .social-icon {
   margin-right: 16px;
+}
+
+.social-outbound-icon {
+  margin: 0 0 2px 8px;
 }
 
 .social-icon.paper {


### PR DESCRIPTION
## Post Launch Updates
- Add social outbound-link icons
- Address logo flicker
- Add jQuery for bootstrap

**Social outbound-link icons**
Before | After
------------ | -------------
<img width="1324" alt="Screen Shot 2021-08-06 at 11 25 38 AM" src="https://user-images.githubusercontent.com/21027134/128557880-e88d35a8-5dad-4a5c-9bd5-944fce3269df.png"> | <img width="1159" alt="Screen Shot 2021-08-06 at 11 39 03 AM" src="https://user-images.githubusercontent.com/21027134/128557889-efcf99f2-5c46-4cb3-b1b0-c1c92065acdc.png">

**Logo flicker**
https://user-images.githubusercontent.com/21027134/128558079-abb3e2fa-cd44-47df-aba3-0788b08d4ac7.mp4

**jQuery for Bootstrap**
<img width="1039" alt="Screen Shot 2021-08-06 at 11 54 31 AM" src="https://user-images.githubusercontent.com/21027134/128558637-1df9702d-089d-44dd-b571-4b64a79ea4b1.png">
